### PR TITLE
bugfix/SKOOP-151

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     image: 'neo4j:3.4'
     environment:
       NEO4J_AUTH: neo4j/topsecret
+      NEO4J_dbms_connector_bolt_thread__pool__min__size: 50
     volumes:
       - 'server-data:/data'
     restart: always


### PR DESCRIPTION
Neo4j DBMS connector bolt thread pool minimal size has been set to 50 according to the default value of Neo4j OGM configuration.

See https://github.com/neo4j/neo4j-ogm/blob/3.1.x/api/src/main/java/org/neo4j/ogm/config/Configuration.java#L84

Another option to fix "Connection to the database failed" issue would be to set org.neo4j.driver.v1.Config.ConfigBuilder#idleTimeBeforeConnectionTest.

See https://github.com/neo4j/neo4j-java-driver/blob/1.6/driver/src/main/java/org/neo4j/driver/v1/Config.java#L423

But as the JavaDoc [says](https://github.com/neo4j/neo4j-java-driver/blob/1.6/driver/src/main/java/org/neo4j/driver/v1/Config.java#L412) "You normally should not need to tune this parameter". Thereby it was decided to adjust database instance according to the default driver settings.